### PR TITLE
Only use adata.uns['liana_res'] if inplace==False

### DIFF
--- a/liana/method/sc/_rank_aggregate.py
+++ b/liana/method/sc/_rank_aggregate.py
@@ -155,9 +155,10 @@ class AggregateClass(MethodMeta):
                                _aggregate_method=aggregate_method,
                                _consensus_opts=consensus_opts
                                )
-        adata.uns[key_added] = liana_res
-
-        return None if inplace else liana_res
+        if inplace == False:
+            return liana_res
+        else:
+            adata.uns['liana_res'] = liana_res
 
 _rank_aggregate_meta = \
     MethodMeta(method_name="Rank_Aggregate",


### PR DESCRIPTION
If inplace==False, return the liana_res data frame without adding it to the anndata object. This is expected behavior for scanpy inplace arguments.