### PR TITLE
keep psbulk stats when converting to MuData

### DIFF
--- a/liana/multi/to_mudata.py
+++ b/liana/multi/to_mudata.py
@@ -49,6 +49,7 @@ def adata_to_views(adata,
                    min_total_count=15,
                    large_n=10, 
                    min_prop=0.1,
+                   keep_psbulk_stats = False,
                    verbose=False,
                    **kwargs):
     """
@@ -74,6 +75,8 @@ def adata_to_views(adata,
         Number of samples per group that is considered to be "large".
     min_prop:
         Minimum proportion of samples that must have a count for a gene to be included in the pseudobulk.
+    keep_psbulk_stats:
+        If True, keep the pseudobulk statistics in `mdata.uns['psbulk_stats']`.
     verbose:
         If True, show progress bar.
     **kwargs
@@ -93,6 +96,7 @@ def adata_to_views(adata,
     views = tqdm(views, disable=not verbose)
     
     padatas = {}
+    if keep_psbulk_stats: stats = []
     for view in (views):
         # filter AnnData to view
         temp = adata[adata.obs[groupby] == view].copy()
@@ -120,6 +124,12 @@ def adata_to_views(adata,
 
         # only append views that pass QC
         if 0 not in padata.shape:
+            # keep psbulk stats
+            if keep_psbulk_stats:
+                df = padata.obs.filter(items=['psbulk_n_cells', 'psbulk_counts'], axis=1)
+                df.columns = [view + view_separator + col for col in df.columns]
+                stats.append(df)
+
             del padata.obs
             padatas[view] = padata
 
@@ -128,6 +138,10 @@ def adata_to_views(adata,
     
     # process metadata
     _process_meta(adata=adata, mdata=mdata, sample_key=sample_key, obs_keys=obs_keys)
+    
+    # combine psbulk stats across views and add to mdata
+    if keep_psbulk_stats:
+        mdata.uns['psbulk_stats'] = pd.concat(stats, axis=1)
     
     return mdata
 


### PR DESCRIPTION
- adds data frame to .uns of MuData, which contains the number of cells and counts per view
- stats come from pseudobulk function from decoupler and were stored in `adata.obs`
- previous behaviour was to delete all obs and these stats