### PR TITLE
Update _tileplot.py for plotnine >=0.13

### DIFF
--- a/liana/plotting/_tileplot.py
+++ b/liana/plotting/_tileplot.py
@@ -106,7 +106,7 @@ def tileplot(adata: ad.AnnData = None,
         p9.ggplot(liana_res, p9.aes(x='cell_type', y='interaction', fill=fill)) +
         p9.geom_tile() +
         p9.geom_text(p9.aes(label=label), size=label_size, color='white') +
-        p9.facet_grid(facets='~ type', scales='free') +
+        p9.facet_grid('~ type', scales='free') +
         p9.theme_bw(base_size=14) +
         p9.theme(
             axis_text_x=p9.element_text(angle=90),


### PR DESCRIPTION
With `plotnine>=0.13` they changed the interface of `facet_grid` (see [Release notes](https://github.com/has2k1/plotnine/releases/tag/v0.13.0)); there's not more argument `facets`  and doing something like [the tutorial](https://liana-py.readthedocs.io/en/latest/notebooks/targeted.html)
```python
li.pl.tileplot(liana_res=lr_res,
               fill = 'expr',
               label='padj',
               label_fun = lambda x: '*' if x < 0.05 else np.nan,
               top_n=15,
               orderby = 'interaction_stat',
               orderby_ascending = False,
               orderby_absolute = False,
               source_title='Ligand',
               target_title='Receptor',
               )
```
will fail with plotnine>=0.13. 

As a simple fix, just remove the named argument in facet_grid solves the issue and is backwards compatible.
Thanks for creating this awesome package!
