### PR TITLE
pin `anndata` to `<=0.10.8` due to scverse/mudata#77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-anndata = ">=0.7.4"
+anndata = ">=0.7.4,<=0.10.8"
 mudata = "*"
 scanpy = ">=1.8.0"
 numba = ">=0.54.0"


### PR DESCRIPTION
This will be required also with `mudata 0.3.1` if we want to support Py <3.10