### PR TITLE
fix: preserve uns when constructing MistyData from a MuData

### DIFF
--- a/src/liana/method/sp/_misty/_Misty.py
+++ b/src/liana/method/sp/_misty/_Misty.py
@@ -56,10 +56,16 @@ class MistyData(MuData):
                  enforce_obs: bool = True,
                  **kwargs
                  ):
+        # Passing a plain MuData (e.g. from mudata.read_h5mu) keeps only its
+        # per-view dict, so its global .uns would be lost. Preserve it and
+        # restore it after construction.
+        preserved_uns = dict(data.uns) if isinstance(data, MuData) else None
         if isinstance(data, MuData):
             data = data.mod
 
         super().__init__(data, **kwargs)
+        if preserved_uns:
+            self.uns.update(preserved_uns)
         self.view_names = list(self.mod.keys())
         self.spatial_key = spatial_key
         self.enforce_obs = enforce_obs

--- a/tests/test_misty.py
+++ b/tests/test_misty.py
@@ -4,6 +4,8 @@ import pathlib
 import numpy as np
 import scanpy as sc
 
+from mudata import MuData
+
 from liana.method import MistyData
 from liana.method.sp._misty._misty_constructs import genericMistyData, lrMistyData
 from liana.method.sp._misty._single_view_models import LinearModel, RandomForestModel, RobustLinearModel
@@ -13,6 +15,19 @@ test_path = pathlib.Path(__file__).parent
 
 adata = sc.read_h5ad(os.path.join(test_path, "data" , "synthetic.h5ad"))
 adata = sc.pp.subsample(adata, n_obs=100, copy=True)
+
+
+def test_misty_from_mudata_preserves_uns():
+    # Round-tripping through MuData (e.g. mudata.read_h5mu) must not drop .uns
+    misty = genericMistyData(adata, bandwidth=10, cutoff=0, add_juxta=False, set_diag=False)
+    misty.uns["stored"] = {"kept": True}
+
+    mdata = MuData(dict(misty.mod))
+    mdata.uns["stored"] = misty.uns["stored"]
+
+    rebuilt = MistyData(mdata)
+    assert "stored" in rebuilt.uns
+    assert rebuilt.uns["stored"] == {"kept": True}
 
 
 def test_misty_para():


### PR DESCRIPTION
Fixes #242

Following the MISTy tutorial, writing a `MistyData` produces a `MuData` on disk; reading it back with `mudata.read_h5ad` and passing it to `MistyData()` was supposed to reconstruct the object. But `MistyData.__init__` reduced a `MuData` argument to only its per-view `.mod` dict, so the global `.uns` was silently dropped and replaced by a fresh empty one. Anything stored in `uns` (interaction results, target metrics, etc.) was lost on the round trip, which broke downstream steps such as plotting.

The fix captures `data.uns` before reducing to `.mod` and restores it after `super().__init__`.

Added `test_misty_from_mudata_preserves_uns`, which stores a value in `uns`, round-trips through a plain `MuData`, and asserts it survives. Verified the test **fails** without the fix (AssertionError) and **passes** with it:

```
tests/test_misty.py::test_misty_from_mudata_preserves_uns  1 passed
```