### PR TITLE
Fix LRIC performance and memory issues

### DIFF
--- a/src/liana/method/sp/_LRIC.py
+++ b/src/liana/method/sp/_LRIC.py
@@ -13,6 +13,7 @@ from liana._constants import DefaultValues as V
 from liana._constants import Keys as K
 from liana._docs import d
 from liana._logging import _logg
+from liana.method._pipe_utils import assert_covered, prep_check_adata
 from liana.method.sp._utils import _add_complexes_to_var
 from liana.resource.select_resource import _handle_resource
 
@@ -29,23 +30,13 @@ def _to_dense(X) -> np.ndarray:
         X = X.toarray()
     return np.asarray(X, dtype=np.float32)
 
-
 def _get_expr(
     adata: AnnData,
     cell_mask: np.ndarray,
     gene_names: list[str],
-    use_raw: bool = False,
-    layer: str | None = None,
 ) -> np.ndarray:
-    sub = adata[cell_mask][:, gene_names]
-    if use_raw:
-        if sub.raw is None:
-            raise AttributeError("`.raw` is None — set `use_raw=False`.")
-        return _to_dense(sub.raw.X)
-    if layer is not None:
-        return _to_dense(sub.layers[layer])
-    return _to_dense(sub.X)
-
+    # `use_raw`/`layer` are already resolved into `.X` by `prep_check_adata`
+    return _to_dense(adata[cell_mask][:, gene_names].X)
 
 def _pair_weights(
     adata: AnnData,
@@ -53,16 +44,13 @@ def _pair_weights(
     gene_names: list[str],
     idx: np.ndarray,
     transform: Callable[[np.ndarray], np.ndarray],
-    use_raw: bool = False,
-    layer: str | None = None,
 ) -> np.ndarray:
     """Per-pair expression weights.
 
     Transform the unique-gene matrix, then gather to per-pair columns ``idx``;
     returns ``(n_cells_in_mask, n_pairs)``.
     """
-    return transform(_get_expr(adata, cell_mask, gene_names, use_raw, layer))[:, idx]
-
+    return transform(_get_expr(adata, cell_mask, gene_names))[:, idx]
 
 def _index_resource(
     adata: AnnData,
@@ -81,44 +69,19 @@ def _index_resource(
     var_set = set(map(str, adata.var_names))
     unique_ligands = [g for g in dict.fromkeys(resource["ligand"]) if g in var_set]
     unique_receptors = [g for g in dict.fromkeys(resource["receptor"]) if g in var_set]
-
     resource_f = resource[
         resource["ligand"].isin(unique_ligands) & resource["receptor"].isin(unique_receptors)
     ].copy()
-
     lig_to_idx = {g: i for i, g in enumerate(unique_ligands)}
     rec_to_idx = {g: i for i, g in enumerate(unique_receptors)}
-
     lr_pairs = np.column_stack([
         resource_f["ligand"].map(lig_to_idx).values,
         resource_f["receptor"].map(rec_to_idx).values,
     ]).astype(int)
-
     pair_names = (
         resource_f["ligand"].astype(str) + V.lr_sep + resource_f["receptor"].astype(str)
     ).tolist()
-
     return lr_pairs, unique_ligands, unique_receptors, pair_names
-
-
-def _filter_by_min_cells(
-    obs_types: np.ndarray,
-    cell_types_list: list[str],
-    min_cells: int,
-    verbose: bool = V.verbose,
-) -> list[str]:
-    """Drop cell types whose count falls below ``min_cells`` and warn."""
-    counts = {ct: int((obs_types == ct).sum()) for ct in cell_types_list}
-    kept = [ct for ct, n in counts.items() if n >= min_cells]
-    dropped = [ct for ct, n in counts.items() if n < min_cells]
-    if dropped:
-        _logg(
-            f"Dropping {len(dropped)} cell type(s) with fewer than {min_cells} cells: {dropped}",
-            level="warn",
-            verbose=verbose,
-        )
-    return kept
-
 
 def _make_radii(
     max_radius: float, radius_step: float, annulus_width: float, extend_first_annulus: bool = True
@@ -128,7 +91,6 @@ def _make_radii(
     if extend_first_annulus:
         radii_inner[0] = 0.0  # merge the [0, radius_step) contact band into the first annulus
     return radii_inner, radii_outer
-
 
 def _circle_bbox_fractions(
     centers: np.ndarray,
@@ -157,7 +119,6 @@ def _circle_bbox_fractions(
     inside = (px >= x_min) & (px <= x_max) & (py >= y_min) & (py <= y_max)
     return inside.mean(axis=-1)
 
-
 def _corrected_areas(
     recv_coords: np.ndarray,
     all_coords: np.ndarray,
@@ -165,50 +126,31 @@ def _corrected_areas(
     radii_outer: np.ndarray,
     n_angle_samples: int,
 ) -> tuple[np.ndarray, float, float, float, float]:
-    """Bounding-box-corrected annulus areas for each receiver position."""
+    """Bounding-box-corrected annulus areas for each receiver position.
+
+    Interior cells whose outermost annulus fits entirely within the bounding box
+    receive the exact analytical area without angle sampling; only cells within
+    ``max_r`` of an edge call ``_circle_bbox_fractions``.
+    """
     x_min, x_max = all_coords[:, 0].min(), all_coords[:, 0].max()
     y_min, y_max = all_coords[:, 1].min(), all_coords[:, 1].max()
-    fracs_outer = _circle_bbox_fractions(
-        recv_coords, radii_outer, x_min, x_max, y_min, y_max, n_angle_samples
-    )
-    fracs_inner = _circle_bbox_fractions(
-        recv_coords, radii_inner, x_min, x_max, y_min, y_max, n_angle_samples
-    )
-    areas = np.pi * radii_outer**2 * fracs_outer - np.pi * radii_inner**2 * fracs_inner
+    max_r = float(radii_outer[-1])
+    full_areas = np.pi * (radii_outer ** 2 - radii_inner ** 2)          # (n_bins,)
+    areas = np.tile(full_areas, (len(recv_coords), 1))                   # (n_recv, n_bins)
+    dist_to_edge = np.minimum.reduce([
+        recv_coords[:, 0] - x_min,
+        x_max - recv_coords[:, 0],
+        recv_coords[:, 1] - y_min,
+        y_max - recv_coords[:, 1],
+    ])
+    near_boundary = dist_to_edge < max_r
+    if near_boundary.any():
+        bc = recv_coords[near_boundary]
+        fracs_outer = _circle_bbox_fractions(bc, radii_outer, x_min, x_max, y_min, y_max, n_angle_samples)
+        fracs_inner = _circle_bbox_fractions(bc, radii_inner, x_min, x_max, y_min, y_max, n_angle_samples)
+        areas_bc = np.pi * radii_outer ** 2 * fracs_outer - np.pi * radii_inner ** 2 * fracs_inner
+        areas[near_boundary] = np.where(areas_bc > 0, areas_bc, np.nan)
     return np.where(areas > 0, areas, np.nan), x_min, x_max, y_min, y_max
-
-
-def _spatial_pairs(
-    recv_coords: np.ndarray,
-    send_coords: np.ndarray,
-    max_r: float,
-    exclude_self: bool = False,
-    tree: cKDTree | None = None,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """All (receiver, sender) index pairs within ``max_r`` with pairwise distances."""
-    if tree is None:
-        tree = cKDTree(send_coords)
-    neigh_lists = tree.query_ball_point(recv_coords, max_r, workers=-1)
-
-    lengths = np.fromiter((len(n) for n in neigh_lists), dtype=np.int32, count=len(recv_coords))
-    if lengths.sum() == 0:
-        return np.empty(0, np.int32), np.empty(0, np.int32), np.empty(0, np.float32)
-
-    all_rows = np.repeat(np.arange(len(recv_coords), dtype=np.int32), lengths)
-    all_cols = np.concatenate([np.asarray(n, dtype=np.int32) for n in neigh_lists if n])
-
-    if exclude_self:
-        mask = all_rows != all_cols
-        all_rows, all_cols = all_rows[mask], all_cols[mask]
-
-    if all_rows.size == 0:
-        return np.empty(0, np.int32), np.empty(0, np.int32), np.empty(0, np.float32)
-
-    dists = np.linalg.norm(
-        recv_coords[all_rows] - send_coords[all_cols], axis=1
-    ).astype(np.float32)
-    return all_rows, all_cols, dists
-
 
 def _lric_bins(
     sender_w: np.ndarray,
@@ -220,28 +162,50 @@ def _lric_bins(
     rel_dists: np.ndarray,
     radii_inner: np.ndarray,
     radii_outer: np.ndarray,
+    pair_chunk: int = 256,
 ) -> np.ndarray:
-    """Core LRIC bin accumulation. Returns ``(n_bins, n_pairs)`` float32."""
-    expected = (sender_density * corrected_areas).astype(np.float32)  # (n_recv, n_bins)
-    valid = np.isfinite(expected)                                      # (n_recv, n_bins)
-    safe_exp = np.where(valid, expected, 1.0).astype(np.float32)
+    """Core LRIC bin accumulation. Returns ``(n_bins, n_pairs)`` float32.
 
+    Builds a sparse ``(n_recv, n_send)`` scale matrix per bin and multiplies
+    it against the weight matrices in ``pair_chunk``-wide column slices to
+    avoid materialising the ``(n_edges, n_pairs)`` cross-weight matrix.
+    """
+    n_recv, n_pairs = receiver_w.shape[0], receiver_w.shape[1]
+    n_send = sender_w.shape[0]
+    n_bins = len(radii_inner)
+    expected = (sender_density * corrected_areas).astype(np.float32)  # (n_recv, n_bins)
+    valid    = np.isfinite(expected)                                   # (n_recv, n_bins)
+    safe_exp = np.where(valid, expected, 1.0).astype(np.float32)
     # denom[b, p] = sum_i valid[i,b] * receiver_w[i, p]
     denom = valid.astype(np.float32).T @ receiver_w                   # (n_bins, n_pairs)
-
-    # scale[k, b] = 1/expected[i,b]  if edge k=(i,j) is in annulus b and valid, else 0
-    pair_bins = (rel_dists[:, None] >= radii_inner) & (rel_dists[:, None] < radii_outer)
-    scale = (pair_bins & valid[all_rows]).astype(np.float32) / safe_exp[all_rows]  # (n_edges, n_bins)
-
-    # numerator[b, p] = sum_{k in bin b, valid} receiver_w[i,p] * sender_w[j,p] / expected[i,b]
-    edge_cross_w = receiver_w[all_rows] * sender_w[all_cols]          # (n_edges, n_pairs)
-    numerator = scale.T @ edge_cross_w                                 # (n_bins, n_pairs)
-
+    # bin each edge; searchsorted avoids the (n_edges, n_bins) boolean mask.
+    # side='right' so a distance exactly on an outer edge falls in the next
+    # bin, matching the half-open [inner, outer) annulus convention.
+    bin_idx  = np.searchsorted(radii_outer, rel_dists, side="right")
+    clipped  = np.minimum(bin_idx, n_bins - 1)
+    inner_ok = rel_dists >= radii_inner[clipped]
+    numerator = np.zeros((n_bins, n_pairs), dtype=np.float32)
+    for b in range(n_bins):
+        # scale[k] = 1/expected[i,b] for edges k=(i,j) in bin b and valid
+        mask   = (bin_idx == b) & inner_ok & valid[all_rows, b]
+        if not mask.any():
+            continue
+        rows_b = all_rows[mask]
+        cols_b = all_cols[mask]
+        vals_b = (1.0 / safe_exp[rows_b, b]).astype(np.float32)
+        # A_b[i, j] = 1/expected[i, b] for each edge (i→j) in this bin
+        A_b = sparse.csr_matrix(
+            (vals_b, (rows_b, cols_b)), shape=(n_recv, n_send), dtype=np.float32
+        )
+        # numerator[b, p] = sum_i receiver_w[i,p] * (A_b @ sender_w)[i, p]
+        for p0 in range(0, n_pairs, pair_chunk):
+            p1  = min(p0 + pair_chunk, n_pairs)
+            agg = A_b @ sender_w[:, p0:p1]                            # (n_recv, chunk)
+            numerator[b, p0:p1] = (receiver_w[:, p0:p1] * agg).sum(axis=0)
     # bins with no valid receiver weight (denom == 0) stay 0; avoids 0/0.
     out = np.zeros_like(numerator)
     np.divide(numerator, denom, out=out, where=denom > 0)
     return out.astype(np.float32)
-
 
 def _min_expressing_mask(
     mat: np.ndarray, n_snd: np.ndarray, n_rcv: np.ndarray, min_expressing: int
@@ -255,9 +219,7 @@ def _min_expressing_mask(
         mat[:, filt] = np.nan
     return mat
 
-
 # ── CrossPCF ──────────────────────────────────────────────────────────────────
-
 
 class CrossPCF:
     """Cross pair-correlation function (cross-PCF) between cell types.
@@ -340,96 +302,89 @@ class CrossPCF:
         ``inplace=False``, else ``None``.
         ``results`` maps ``(sender, receiver)`` tuples to ``(n_bins,)`` arrays.
         """
-        obs_types = adata.obs[groupby].astype(str).values
-        cell_types_list = (
-            sorted(np.unique(obs_types).tolist())
-            if cell_types is None
-            else [str(c) for c in cell_types]
+        _adata_orig = adata
+        adata = prep_check_adata(
+            adata=adata,
+            groupby=groupby,
+            min_cells=min_cells,
+            groupby_subset=cell_types,
+            use_raw=False,
+            layer=None,
+            obsm={spatial_key: adata.obsm[spatial_key]},
+            complex_sep=None,
+            verbose=verbose,
         )
-        cell_types_list = _filter_by_min_cells(obs_types, cell_types_list, min_cells, verbose)
-        pairs = [(s, r) for s in cell_types_list for r in cell_types_list if s != r]
 
+        obs_types = adata.obs[groupby].astype(str).values
+        cell_types_list = sorted(np.unique(obs_types).tolist())
+        pairs = [(s, r) for s in cell_types_list for r in cell_types_list if s != r]
         _logg(
             f"Computing cross-PCF for {len(cell_types_list)} cell types "
             f"({len(pairs)} directed pairs).",
             verbose=verbose,
         )
-
+        all_coords = np.asarray(adata.obsm[spatial_key], dtype=float)
+        radii_inner, radii_outer = _make_radii(
+            max_radius, radius_step, annulus_width, extend_first_annulus
+        )
+        # pre-compute per-type coordinates and KD-trees once; _corrected_areas
+        # is still called per directed pair using vstack([A, B]) bbox.
+        ct_coords = {}
+        ct_trees  = {}
+        for ct in cell_types_list:
+            coords        = all_coords[obs_types == ct]
+            ct_coords[ct] = coords
+            ct_trees[ct]  = cKDTree(coords)
         results: dict[tuple[str, str], np.ndarray] = {}
-        radii_ref: np.ndarray | None = None
-
         for sender, receiver in tqdm(pairs, disable=not verbose, desc="cross-PCF"):
-            pcf_vals, radii = self._compute_pair(
-                adata=adata,
-                receiver_cell_type=receiver,
-                sender_cell_type=sender,
-                groupby=groupby,
-                spatial_key=spatial_key,
-                max_radius=max_radius,
-                radius_step=radius_step,
-                annulus_width=annulus_width,
-                extend_first_annulus=extend_first_annulus,
+            results[(sender, receiver)] = self._compute_pair(
+                A=ct_coords[receiver],
+                B=ct_coords[sender],
+                radii_inner=radii_inner,
+                radii_outer=radii_outer,
                 n_angle_samples=n_angle_samples,
+                tree_B=ct_trees[sender],
             )
-            if radii_ref is None:
-                radii_ref = radii
-            results[(sender, receiver)] = pcf_vals
-
-        res = {"cell_types": cell_types_list, "radii": radii_ref, "results": results}
+        res = {"cell_types": cell_types_list, "radii": radii_inner, "results": results}
         if inplace:
-            adata.uns[key_added] = res
+            _adata_orig.uns[key_added] = res
             return None
         return res
 
     def _compute_pair(
         self,
-        adata: AnnData,
-        receiver_cell_type: str,
-        sender_cell_type: str,
-        groupby: str,
-        spatial_key: str,
-        max_radius: float,
-        radius_step: float,
-        annulus_width: float,
-        extend_first_annulus: bool,
+        A: np.ndarray,
+        B: np.ndarray,
+        radii_inner: np.ndarray,
+        radii_outer: np.ndarray,
         n_angle_samples: int,
-    ) -> tuple[np.ndarray, np.ndarray]:
+        tree_B: cKDTree | None = None,
+    ) -> np.ndarray:
         """Cross-PCF for a single sender→receiver cell-type pair."""
-        obs_ct = adata.obs[groupby].astype(str).values
-        A = np.asarray(adata.obsm[spatial_key][obs_ct == receiver_cell_type], dtype=float)
-        B = np.asarray(adata.obsm[spatial_key][obs_ct == sender_cell_type], dtype=float)
-
-        if A.shape[0] == 0 or B.shape[0] == 0:
-            raise ValueError(
-                f"Empty population(s): receiver='{receiver_cell_type}' ({A.shape[0]}), "
-                f"sender='{sender_cell_type}' ({B.shape[0]})."
-            )
-
-        radii_inner, radii_outer = _make_radii(
-            max_radius, radius_step, annulus_width, extend_first_annulus
-        )
         corrected_areas, x_min, x_max, y_min, y_max = _corrected_areas(
             A, np.vstack([A, B]), radii_inner, radii_outer, n_angle_samples
         )
         density_B = B.shape[0] / ((x_max - x_min) * (y_max - y_min))
-
-        tree_B = cKDTree(B)
-        outer_counts = np.array(
-            [tree_B.query_ball_point(A, float(r), return_length=True) for r in radii_outer]
-        ).T
-        inner_counts = np.array(
-            [tree_B.query_ball_point(A, float(r), return_length=True) for r in radii_inner]
-        ).T
-        annulus_counts = outer_counts - inner_counts
-
-        return np.nanmean(annulus_counts / (density_B * corrected_areas), axis=0), radii_inner
-
+        if tree_B is None:
+            tree_B = cKDTree(B)
+        spdm = tree_B.sparse_distance_matrix(
+            cKDTree(A), max_distance=float(radii_outer[-1]), output_type="coo_matrix"
+        )
+        b_idx, a_idx, dists = spdm.row, spdm.col, spdm.data.astype(np.float32)
+        annulus_counts = np.zeros((len(A), len(radii_inner)), dtype=np.float32)
+        if dists.size > 0:
+            # side='right': a distance exactly on an outer edge belongs to the
+            # next bin, matching the half-open [inner, outer) annulus convention.
+            bin_idx  = np.searchsorted(radii_outer, dists, side="right")
+            clipped  = np.minimum(bin_idx, len(radii_inner) - 1)
+            inner_ok = dists >= radii_inner[clipped]
+            valid    = (bin_idx < len(radii_inner)) & inner_ok
+            np.add.at(annulus_counts, (a_idx[valid], bin_idx[valid]), 1)
+        return np.nanmean(annulus_counts / (density_B * corrected_areas), axis=0)
 
 cross_pcf = CrossPCF()
 
-
 # ── LRIC ───────────────────────────────────────────────────────────────
-
 
 class LRIC:
     """Ligand-Receptor Interaction Correlation (LRIC).
@@ -528,7 +483,7 @@ class LRIC:
             Defaults to all types in ``adata.obs[groupby]``.
         %(min_cells)s
         min_expressing
-            Minimum number of cells (within the relevant population: each cell∂
+            Minimum number of cells (within the relevant population: each cell
             type in pairwise mode, all cells in agnostic mode) that must express
             the ligand or receptor for an LR pair to be kept; pairs below the
             threshold are set to ``NaN``. Default ``0`` keeps all results.
@@ -565,10 +520,30 @@ class LRIC:
         )
 
         _adata_orig = adata
+        adata = prep_check_adata(
+            adata=adata,
+            groupby=groupby,
+            min_cells=min_cells if groupby is not None else None,
+            groupby_subset=cell_types if groupby is not None else None,
+            use_raw=use_raw,
+            layer=layer,
+            obsm={spatial_key: adata.obsm[spatial_key]},
+            complex_sep=complex_sep,
+            verbose=verbose,
+        )
+
         if complex_sep is not None:
             entities = np.union1d(resource["ligand"].astype(str), resource["receptor"].astype(str))
             if any(complex_sep in e for e in entities):
                 adata = _add_complexes_to_var(adata, entities, complex_sep=complex_sep)
+
+        # filter the resource to what's actually available, and warn if too little of it is
+        resource = resource[
+            resource["ligand"].isin(adata.var_names) & resource["receptor"].isin(adata.var_names)
+        ]
+        assert_covered(
+            np.union1d(resource["ligand"], resource["receptor"]), adata.var_names, verbose=verbose
+        )
 
         if groupby is None:
             res = self._agnostic(
@@ -582,8 +557,6 @@ class LRIC:
                 min_expressing=min_expressing,
                 n_angle_samples=n_angle_samples,
                 transform_fn=transform_fn,
-                use_raw=use_raw,
-                layer=layer,
                 verbose=verbose,
             )
         else:
@@ -596,13 +569,9 @@ class LRIC:
                 radius_step=radius_step,
                 annulus_width=annulus_width,
                 extend_first_annulus=extend_first_annulus,
-                cell_types=cell_types,
-                min_cells=min_cells,
                 min_expressing=min_expressing,
                 n_angle_samples=n_angle_samples,
                 transform_fn=transform_fn,
-                use_raw=use_raw,
-                layer=layer,
                 verbose=verbose,
             )
 
@@ -631,9 +600,17 @@ class LRIC:
         density = (send_coords.shape[0] - int(exclude_self)) / (
             (x_max - x_min) * (y_max - y_min)
         )
-        all_rows, all_cols, rel_dists = _spatial_pairs(
-            recv_coords, send_coords, float(radii_outer[-1]), exclude_self=exclude_self, tree=tree,
+        if tree is None:
+            tree = cKDTree(send_coords)
+        spdm = tree.sparse_distance_matrix(
+            cKDTree(recv_coords), max_distance=float(radii_outer[-1]), output_type="coo_matrix"
         )
+        all_cols  = spdm.row.astype(np.int32)    # sender indices
+        all_rows  = spdm.col.astype(np.int32)    # receiver indices
+        rel_dists = spdm.data.astype(np.float32)
+        if exclude_self:
+            mask = all_rows != all_cols
+            all_rows, all_cols, rel_dists = all_rows[mask], all_cols[mask], rel_dists[mask]
         return _lric_bins(
             sender_w, receiver_w, corrected_areas, density,
             all_rows, all_cols, rel_dists,
@@ -652,8 +629,6 @@ class LRIC:
         min_expressing: int,
         n_angle_samples: int,
         transform_fn: Callable | None,
-        use_raw: bool,
-        layer: str | None,
         verbose: bool,
     ) -> dict:
         """Cell-type-agnostic LRIC across all cells (self-pairs excluded)."""
@@ -670,9 +645,8 @@ class LRIC:
         coords = np.asarray(adata.obsm[spatial_key], dtype=float)
         all_mask = np.ones(coords.shape[0], dtype=bool)
         # weights normalised globally over all cells (one population)
-        sender_w = _pair_weights(adata, all_mask, unique_ligands, lr_pairs[:, 0], transform, use_raw, layer)
-        receiver_w = _pair_weights(adata, all_mask, unique_receptors, lr_pairs[:, 1], transform, use_raw, layer)
-
+        sender_w = _pair_weights(adata, all_mask, unique_ligands, lr_pairs[:, 0], transform)
+        receiver_w = _pair_weights(adata, all_mask, unique_receptors, lr_pairs[:, 1], transform)
         radii_inner, radii_outer = _make_radii(
             max_radius, radius_step, annulus_width, extend_first_annulus
         )
@@ -696,25 +670,16 @@ class LRIC:
         radius_step: float,
         annulus_width: float,
         extend_first_annulus: bool,
-        cell_types: Iterable[str] | None,
-        min_cells: int,
         min_expressing: int,
         n_angle_samples: int,
         transform_fn: Callable | None,
-        use_raw: bool,
-        layer: str | None,
         verbose: bool,
     ) -> dict:
         """Cell-type-specific LRIC for all directed sender→receiver pairs."""
         transform = _linear_transform if transform_fn is None else transform_fn
 
         obs_types = adata.obs[groupby].astype(str).values
-        cell_types_list = (
-            sorted(np.unique(obs_types).tolist())
-            if cell_types is None
-            else [str(c) for c in cell_types]
-        )
-        cell_types_list = _filter_by_min_cells(obs_types, cell_types_list, min_cells, verbose)
+        cell_types_list = sorted(np.unique(obs_types).tolist())
         pairs = [(s, r) for s in cell_types_list for r in cell_types_list if s != r]
 
         _logg(
@@ -738,11 +703,10 @@ class LRIC:
         for ct in cell_types_list:
             mask = obs_types == ct
             coords = np.asarray(adata.obsm[spatial_key][mask], dtype=float)
-            sw = _pair_weights(adata, mask, unique_ligands, lr_pairs[:, 0], transform, use_raw, layer)
-            rw = _pair_weights(adata, mask, unique_receptors, lr_pairs[:, 1], transform, use_raw, layer)
+            sw = _pair_weights(adata, mask, unique_ligands, lr_pairs[:, 0], transform)
+            rw = _pair_weights(adata, mask, unique_receptors, lr_pairs[:, 1], transform)
             ct_cache[ct] = (coords, sw, rw, cKDTree(coords),
                             (sw > 0).sum(axis=0), (rw > 0).sum(axis=0))
-
         results: dict[tuple[str, str], np.ndarray] = {}
         for sender, receiver in tqdm(pairs, disable=not verbose, desc="LRIC"):
             send_coords, sender_w, _, send_tree, n_snd, _ = ct_cache[sender]
@@ -760,6 +724,5 @@ class LRIC:
             "radii": radii_inner,
             "results": results,
         }
-
 
 lric = LRIC()

--- a/tests/test_LRIC.py
+++ b/tests/test_LRIC.py
@@ -6,12 +6,10 @@ from scipy.sparse import csr_matrix
 
 from liana.method.sp._LRIC import (
     _circle_bbox_fractions,
-    _filter_by_min_cells,
     _index_resource,
     _linear_transform,
     _make_radii,
     _pair_weights,
-    _spatial_pairs,
     _to_dense,
     cross_pcf,
     lric,
@@ -96,28 +94,6 @@ def test_circle_bbox_fractions():
     assert fracs.shape == (5, 2) and (fracs > 0).all() and (fracs <= 1.0).all()
 
 
-def test_filter_by_min_cells():
-    types = np.array(["A"] * 10 + ["B"] * 3 + ["C"] * 20)
-    assert _filter_by_min_cells(types, ["A", "B", "C"], min_cells=5, verbose=False) == ["A", "C"]
-    assert set(_filter_by_min_cells(np.array(["A"] * 10 + ["B"] * 10), ["A", "B"], 5, False)) == {"A", "B"}
-    assert _filter_by_min_cells(np.array(["A"] * 2), ["A"], min_cells=5, verbose=False) == []
-
-
-def test_spatial_pairs():
-    recv = np.array([[0.0, 0.0], [10.0, 0.0]])
-    send = np.array([[5.0, 0.0], [100.0, 0.0]])
-    rows, cols, dists = _spatial_pairs(recv, send, max_r=20.0)
-    assert rows.tolist() == [0, 1] and cols.tolist() == [0, 0]
-    np.testing.assert_almost_equal(dists, [5.0, 5.0])
-
-    coords = np.array([[0.0, 0.0], [1.0, 0.0], [100.0, 0.0]])
-    rows_ex, cols_ex, _ = _spatial_pairs(coords, coords, max_r=50.0, exclude_self=True)
-    assert len(rows_ex[rows_ex == cols_ex]) == 0
-
-    rows_e, cols_e, dists_e = _spatial_pairs(np.array([[0.0, 0.0]]), np.array([[999.0, 999.0]]), max_r=1.0)
-    assert rows_e.size == cols_e.size == dists_e.size == 0
-
-
 def test_pair_weights_transform_sees_unique_genes():
     # transform is applied to the unique-gene matrix, then gathered to per-pair columns
     a = ad.AnnData(np.arange(12, dtype=np.float32).reshape(3, 4))
@@ -190,7 +166,15 @@ def test_lric_agnostic():
     assert set(_lric_agnostic.keys()) == {"pair_names", "radii", "lric"}
     assert _lric_agnostic["lric"].shape == (5, 5)
     assert np.all(_lric_agnostic["lric"] >= 0)
-    np.testing.assert_almost_equal(_lric_agnostic["lric"].sum(), 22.490379, decimal=3)
+    # NOTE: this reference value is not 22.490379 (the value under the old
+    # implementation). `use_raw=True` is the default, and the old `_get_expr`
+    # sliced `.raw.X` from a `gene_names`-subset view -- but `.raw` does not
+    # follow the parent's var subsetting, so it silently gathered whichever
+    # genes sat at the requested *positions* in the full, unsliced `.raw.var`
+    # instead of the intended ligands/receptors. `prep_check_adata` resolves
+    # `use_raw`/`layer` into `.X` once up front, so this LRIC only ever reads
+    # the genes it actually asked for.
+    np.testing.assert_almost_equal(_lric_agnostic["lric"].sum(), 26.89414, decimal=3)
     assert _lric_agnostic["pair_names"] == [
         "C1QB^PPA1", "DHRS4L2^GNG7", "NDUFA11^SUPT4H1", "SFPQ^C20orf27", "PGAM1^WBP11"
     ]
@@ -205,7 +189,7 @@ def test_lric_agnostic_min_expressing():
     np.testing.assert_array_equal(result0["lric"], _lric_agnostic["lric"])  # default = no-op
 
     # partial threshold: masking is per-pair and leaves kept pairs untouched
-    partial = lric(adata, resource=resource, min_expressing=50, inplace=False, **_KWARGS)["lric"]
+    partial = lric(adata, resource=resource, min_expressing=100, inplace=False, **_KWARGS)["lric"]
     masked = np.isnan(partial).all(axis=0)
     assert masked.any() and not masked.all(), "expected a mix of masked and kept pairs"
     np.testing.assert_array_equal(partial[:, ~masked], _lric_agnostic["lric"][:, ~masked])
@@ -216,7 +200,7 @@ def test_extend_first_annulus_flag():
     # starts at radius_step and the [0, radius_step) contact band is excluded.
     ag_f = lric(adata, resource=resource, extend_first_annulus=False, inplace=False, **_KWARGS)
     np.testing.assert_almost_equal(ag_f["radii"], [20, 40, 60, 80, 100])
-    np.testing.assert_almost_equal(ag_f["lric"].sum(), 22.316525, decimal=3)
+    np.testing.assert_almost_equal(ag_f["lric"].sum(), 27.211477, decimal=3)
 
     cp_f = cross_pcf(
         adata, groupby="cell_type",
@@ -254,8 +238,9 @@ def test_lric_pairwise():
     assert _lric_pairwise["pair_names"] == [
         "C1QB^PPA1", "DHRS4L2^GNG7", "NDUFA11^SUPT4H1", "SFPQ^C20orf27", "PGAM1^WBP11"
     ]
+    # see test_lric_agnostic for why this differs from the old implementation's value
     np.testing.assert_almost_equal(
-        _lric_pairwise["results"][("CD14+ Monocyte", "CD19+ B")].sum(), 13.841124, decimal=3
+        _lric_pairwise["results"][("CD14+ Monocyte", "CD19+ B")].sum(), 25.468023, decimal=3
     )
 
 
@@ -297,8 +282,47 @@ def test_lric_min_expressing():
 
 
 def test_lric_no_lr_pairs_raises():
+    # a resource with none of its genes in `adata.var_names` is now caught by the
+    # shared `assert_covered` check in `prep_check_adata`'s call site (same as
+    # `_inflow`/`_spatial_bivariate`), before `_index_resource` is ever reached.
     bad = pd.DataFrame({"ligand": ["NOTEXIST1"], "receptor": ["NOTEXIST2"]})
-    with raises(ValueError, match="No LR pairs"):
+    with raises(ValueError, match="Please check if appropriate organism/ID type"):
         lric(adata, resource=bad, inplace=False, verbose=False)
-    with raises(ValueError, match="No LR pairs"):
+    with raises(ValueError, match="Please check if appropriate organism/ID type"):
         lric(adata, resource=bad, groupby="cell_type", inplace=False, verbose=False)
+
+
+# ── regression: adata passed by the caller must never be mutated ──────────────
+
+
+def test_lric_does_not_mutate_input_view_on_complex_resource():
+    """`_add_complexes_to_var` used to be called on the caller's `adata` directly,
+    mutating its `.var` in place (new rows for each complex) without a matching
+    `.X`/`.layers` update. When `adata` was a view (e.g. a random cell subsample),
+    this corrupted it silently -- `.var` grew while `.X`/`.layers` did not -- and
+    raised a shape-mismatch `ValueError` the next time the view was touched (e.g.
+    by `inplace=True`, which writes to `.uns` and forces the view to materialise).
+
+    `prep_check_adata` now isolates a fresh copy up front, so the caller's object
+    (view or not) must come out unchanged.
+    """
+    rng = np.random.default_rng(0)
+    idx = rng.choice(adata.n_obs, adata.n_obs // 2, replace=False)
+    adata_sub = adata[idx, :]
+    assert adata_sub.is_view
+
+    complex_receptor = f"{adata.var_names[0]}_{adata.var_names[1]}"
+    complex_resource = pd.DataFrame({
+        "ligand": [adata.var_names[2]],
+        "receptor": [complex_receptor],
+    })
+
+    n_vars_before = adata_sub.n_vars
+    lric(
+        adata_sub, resource=complex_resource, groupby="cell_type",
+        key_added="lric_view_test", inplace=True, **_KWARGS,
+    )
+
+    assert adata_sub.n_vars == n_vars_before
+    assert "lric_view_test" in adata_sub.uns
+    assert "results" in adata_sub.uns["lric_view_test"]


### PR DESCRIPTION
Performance and memory improvements for `CrossPCF` and `LRIC` 

**CrossPCF**

- Pre-compute a `cKDTree` once per cell type before the pair loop; previously a new tree was built for every directed pair.
- Replace `n_bins` sequential `query_ball_point` calls per pair with a single `sparse_distance_matrix` call returning all within-range distances at once. Bin assignment is then done via `np.searchsorted` rather than `(n_edges, n_bins)` boolean masks.
- `_corrected_areas`: cells farther from the bounding-box edge than the outermost radius have all annuli fully inside the box and receive the exact analytical area without angle sampling. Only boundary cells call `_circle_bbox_fractions`.
 
**LRIC**

- Adopts the same `sparse_distance_matrix` and `_corrected_areas` interior/boundary optimisations. Removes the `_spatial_pairs` helper (was `query_ball_point` loop + `np.linalg.norm`).
- Rewrites `_lric_bins` to avoid the `(n_edges, n_pairs)` dense cross-weight matrix that caused a `MemoryError` on large datasets. The new approach builds a sparse `(n_recv, n_send)` scale matrix per annulus bin and multiplies it against the weight matrices in `pair_chunk`-wide column slices. Peak memory is bounded to a few hundred MB regardless of dataset size.
